### PR TITLE
🐛 👷  Use root option of cspell

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,3 +65,5 @@ jobs:
       - uses: actions/checkout@v3
       - name: Check spelling
         uses: streetsidesoftware/cspell-action@v2
+        with:
+          root: ${{ matrix.package }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,9 +58,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.packages.outputs.package) }}
-    defaults:
-      run:
-        working-directory: ${{ matrix.package }}
     steps:
       - uses: actions/checkout@v3
       - name: Check spelling


### PR DESCRIPTION
This PR uses the `root` option from cspell as suggested in https://github.com/streetsidesoftware/cspell-action/issues/750